### PR TITLE
fix: implement proper route protection for dashboard

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,4 @@
 import { auth } from "@clerk/nextjs/server"
-import { redirect } from "next/navigation"
 import Link from "next/link"
 import { format, parseISO } from "date-fns"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -14,7 +13,6 @@ export default async function DashboardPage({
   searchParams: Promise<{ date?: string; workout?: string }>
 }) {
   const { userId } = await auth()
-  if (!userId) redirect("/sign-in")
 
   const { date: dateParam, workout: workoutParam } = await searchParams
   const dateStr = dateParam ?? format(new Date(), "yyyy-MM-dd")

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -14,6 +14,10 @@ export default async function DashboardPage({
 }) {
   const { userId } = await auth()
 
+  if (!userId) {
+    throw new Error("Unauthorized")
+  }
+
   const { date: dateParam, workout: workoutParam } = await searchParams
   const dateStr = dateParam ?? format(new Date(), "yyyy-MM-dd")
   const date = dateParam ? parseISO(dateParam) : new Date()

--- a/src/app/dashboard/workout/[id]/edit/page.tsx
+++ b/src/app/dashboard/workout/[id]/edit/page.tsx
@@ -1,5 +1,5 @@
 import { auth } from "@clerk/nextjs/server";
-import { redirect, notFound } from "next/navigation";
+import { notFound } from "next/navigation";
 import { getWorkoutById } from "@/data/workouts";
 import { EditWorkoutClient } from "./edit-workout-client";
 
@@ -9,7 +9,6 @@ export default async function EditWorkoutPage({
   params: Promise<{ id: string }>;
 }) {
   const { userId } = await auth();
-  if (!userId) redirect("/sign-in");
 
   const { id: workoutId } = await params;
   const id = parseInt(workoutId);

--- a/src/app/dashboard/workout/[id]/edit/page.tsx
+++ b/src/app/dashboard/workout/[id]/edit/page.tsx
@@ -9,6 +9,9 @@ export default async function EditWorkoutPage({
   params: Promise<{ id: string }>;
 }) {
   const { userId } = await auth();
+  if (!userId) {
+    throw new Error("Unauthorized");
+  }
 
   const { id: workoutId } = await params;
   const id = parseInt(workoutId);

--- a/src/app/dashboard/workout/[id]/page.tsx
+++ b/src/app/dashboard/workout/[id]/page.tsx
@@ -10,6 +10,9 @@ export default async function WorkoutActivePage({
   params: Promise<{ id: string }>;
 }) {
   const { userId } = await auth();
+  if (!userId) {
+    throw new Error("Unauthorized");
+  }
 
   const { id } = await params;
   const workoutId = parseInt(id);

--- a/src/app/dashboard/workout/[id]/page.tsx
+++ b/src/app/dashboard/workout/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { auth } from "@clerk/nextjs/server";
-import { redirect, notFound } from "next/navigation";
+import { notFound } from "next/navigation";
 import { getWorkoutDetail } from "@/data/workouts";
 import { getAllExercises } from "@/data/exercises";
 import { WorkoutActiveClient } from "./workout-active-client";
@@ -10,7 +10,6 @@ export default async function WorkoutActivePage({
   params: Promise<{ id: string }>;
 }) {
   const { userId } = await auth();
-  if (!userId) redirect("/sign-in");
 
   const { id } = await params;
   const workoutId = parseInt(id);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,12 @@
-import { clerkMiddleware } from "@clerk/nextjs/server";
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
-export default clerkMiddleware();
+const isProtectedRoute = createRouteMatcher(["/dashboard(.*)"]);
+
+export default clerkMiddleware(async (auth, req) => {
+  if (isProtectedRoute(req)) {
+    await auth.protect();
+  }
+});
 
 export const config = {
   matcher: [


### PR DESCRIPTION
- Configure Clerk middleware to protect all /dashboard routes
- Remove redundant auth checks from individual page components
- Users are now redirected to sign-in instead of getting 404 errors
- Server actions retain auth checks as they need separate protection

Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)