### PR TITLE
fix: ensure users redirect to dashboard after login instead of 404 on…

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,4 @@
 import { auth } from "@clerk/nextjs/server"
-import { redirect } from "next/navigation"
 import Link from "next/link"
 import { format, parseISO } from "date-fns"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -14,7 +13,7 @@ export default async function DashboardPage({
   searchParams: Promise<{ date?: string; workout?: string }>
 }) {
   const { userId } = await auth()
-  if (!userId) redirect("/sign-in")
+  if (!userId) throw new Error("User not authenticated")
 
   const { date: dateParam, workout: workoutParam } = await searchParams
   const dateStr = dateParam ?? format(new Date(), "yyyy-MM-dd")

--- a/src/app/dashboard/workout/[id]/edit/page.tsx
+++ b/src/app/dashboard/workout/[id]/edit/page.tsx
@@ -1,5 +1,5 @@
 import { auth } from "@clerk/nextjs/server";
-import { redirect, notFound } from "next/navigation";
+import { notFound } from "next/navigation";
 import { getWorkoutById } from "@/data/workouts";
 import { EditWorkoutClient } from "./edit-workout-client";
 
@@ -9,7 +9,7 @@ export default async function EditWorkoutPage({
   params: Promise<{ id: string }>;
 }) {
   const { userId } = await auth();
-  if (!userId) redirect("/sign-in");
+  if (!userId) throw new Error("User not authenticated");
 
   const { id: workoutId } = await params;
   const id = parseInt(workoutId);

--- a/src/app/dashboard/workout/[id]/page.tsx
+++ b/src/app/dashboard/workout/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { auth } from "@clerk/nextjs/server";
-import { redirect, notFound } from "next/navigation";
+import { notFound } from "next/navigation";
 import { getWorkoutDetail } from "@/data/workouts";
 import { getAllExercises } from "@/data/exercises";
 import { WorkoutActiveClient } from "./workout-active-client";
@@ -10,7 +10,7 @@ export default async function WorkoutActivePage({
   params: Promise<{ id: string }>;
 }) {
   const { userId } = await auth();
-  if (!userId) redirect("/sign-in");
+  if (!userId) throw new Error("User not authenticated");
 
   const { id } = await params;
   const workoutId = parseInt(id);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,10 @@
-import { clerkMiddleware } from "@clerk/nextjs/server";
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
-export default clerkMiddleware();
+const isProtectedRoute = createRouteMatcher(['/dashboard(.*)']);
+
+export default clerkMiddleware(async (auth, req) => {
+  if (isProtectedRoute(req)) await auth.protect();
+});
 
 export const config = {
   matcher: [


### PR DESCRIPTION
… /sign-in

- Updated Clerk middleware to properly protect /dashboard routes using auth.protect()
- Removed manual redirect("/sign-in") calls from dashboard page components
- Changed manual auth checks to throw errors instead (middleware handles redirects)
- Fixes issue where authenticated users were being redirected to non-existent /sign-in route